### PR TITLE
Serialized inventory controlled for products #3366

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - 2.7
+install:
+  - pip install flake8
+  - python setup.py install
+script:
+  - python setup.py test
+  - flake8 .
+notifications:
+  email:
+  - ci-notify@openlabs.co.in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-trytond-stock-lot-serial
-========================
-
-Serialized Inventory Control for Tryton

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,9 @@
+Tryton Serialized Inventory Control
+===================================
+
+This module adds a serialized inventory control field to product, which is used
+by stock shipments while accepting incoming moves. If serialized inventory
+control is set for a product, the quantity of the product can't be greater than
+one for incoming moves. Such moves however can be splitted using "Split" button
+provided by this module in shipment form. Each incoming move with quantity 'n'
+will be replaced by 'n' new incoming moves each with quantity equal to one.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+    __init__
+
+    :copyright: (c) 2013-2014 by Openlabs Technologies & Consulting (P) Limited
+    :license: 3-clause BSD, see LICENSE for more details.
+"""
+from trytond.pool import Pool
+from product import Template
+from stock import ShipmentIn, Move
+
+
+def register():
+    Pool.register(
+        Template,
+        Move,
+        ShipmentIn,
+        module='stock_lot_serial', type_='model'
+    )

--- a/product.py
+++ b/product.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+    stock_lot_serial.product
+
+    Product
+
+    :copyright: (c) 2013-2014 by Openlabs Technologies & Consulting (P) Limited
+    :license: 3-clause BSD, see LICENSE for more details.
+"""
+from trytond.model import fields
+from trytond.pool import PoolMeta
+
+__metaclass__ = PoolMeta
+__all__ = ['Template']
+
+
+class Template:
+    "Product Model"
+    __name__ = 'product.template'
+
+    serialized_inventory_control = fields.Boolean(
+        'Serialized Inventory Control?'
+    )

--- a/product.xml
+++ b/product.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<tryton>
+    <data>
+        <record model="ir.ui.view" id="stock_lot_serial_template_view_form">
+            <field name="model">product.template</field>
+            <field name="inherit" ref="product.template_view_form"/>
+            <field name="name">template_form</field>
+        </record>
+    </data>
+</tryton>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,build,dist,upload.py,doc,scripts,selenium*,proteus*,Flask*,pycountry*
+
+ignore=E126
+
+max-complexity=10
+max-line-length=80

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""
+    setup
+
+    :copyright: (c) 2013-2014 by Openlabs Technologies & Consulting (P) Limited
+    :license: 3-clause BSD, see LICENSE for more details.
+"""
+from setuptools import setup
+import re
+import os
+import ConfigParser
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+config = ConfigParser.ConfigParser()
+config.readfp(open('tryton.cfg'))
+info = dict(config.items('tryton'))
+for key in ('depends', 'extras_depend', 'xml'):
+    if key in info:
+        info[key] = info[key].strip().splitlines()
+major_version, minor_version, _ = info.get('version', '0.0.1').split('.', 2)
+major_version = int(major_version)
+minor_version = int(minor_version)
+
+requires = []
+
+MODULE = 'stock_lot_serial'
+PREFIX = 'openlabs'
+MODULE2PREFIX = {
+}
+
+for dep in info.get('depends', []):
+    if not re.match(r'(ir|res|webdav)(\W|$)', dep):
+        requires.append(
+            '%s_%s >= %s.%s, < %s.%s' % (
+                MODULE2PREFIX.get(dep, 'trytond'), dep,
+                major_version, minor_version, major_version, minor_version + 1
+            )
+        )
+requires.append(
+    'trytond >= %s.%s, < %s.%s' % (
+        major_version, minor_version, major_version, minor_version + 1
+    )
+)
+setup(
+    name='%s_%s' % (PREFIX, MODULE),
+    version=info.get('version', '0.0.1'),
+    description="Tryton module for serialized inventory control.",
+    author="Openlabs Technologies & consulting (P) Limited",
+    author_email='info@openlabs.co.in',
+    url='http://www.openlabs.co.in',
+    package_dir={'trytond.modules.%s' % MODULE: '.'},
+    packages=[
+        'trytond.modules.%s' % MODULE,
+        'trytond.modules.%s.tests' % MODULE,
+    ],
+    package_data={
+        'trytond.modules.%s' % MODULE: info.get('xml', [])
+        + info.get('translation', [])
+        + ['tryton.cfg', 'locale/*.po', 'tests/*.rst', '*.odt']
+        + ['view/*.xml'],
+    },
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Plugins',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: 3-clause BSD License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Framework :: Tryton',
+        'Topic :: Office/Business',
+    ],
+    license='3-clause BSD',
+    install_requires=requires,
+    extras_require={
+        'docs': ['sphinx', 'sphinx_rtd_theme'],
+    },
+    zip_safe=False,
+    entry_points="""
+    [trytond.modules]
+    %s = trytond.modules.%s
+    """ % (MODULE, MODULE),
+    test_suite='tests',
+    test_loader='trytond.test_loader:Loader',
+)

--- a/shipment.xml
+++ b/shipment.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<tryton>
+    <data>
+        <record model="ir.ui.view" id="stock_lot_serial_shipment_in_view_form">
+            <field name="model">stock.shipment.in</field>
+            <field name="inherit" ref="stock.shipment_in_view_form"/>
+            <field name="name">shipment_in_form</field>
+        </record>
+    </data>
+</tryton>

--- a/stock.py
+++ b/stock.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+    stock_lot_serial.stock
+
+    Shipment
+
+    :copyright: (c) 2013-2014 by Openlabs Technologies & Consulting (P) Limited
+    :license: 3-clause BSD, see LICENSE for more details.
+"""
+from trytond.model import ModelView
+from trytond.pool import PoolMeta, Pool
+from trytond.pyson import Eval
+
+__metaclass__ = PoolMeta
+__all__ = ['ShipmentIn']
+
+
+class ShipmentIn:
+    "ShipmentIn"
+    __name__ = "stock.shipment.in"
+
+    @classmethod
+    def __setup__(cls):
+        super(ShipmentIn, cls).__setup__()
+        cls._buttons.update({
+            'split_moves': {
+                'invisible': Eval('state') != 'draft',
+            },
+        })
+
+    def _split_moves(self):
+        "Split incoming moves with quantity greater than 1"
+        Move = Pool().get('stock.move')
+
+        for move in self.incoming_moves:
+            if not move.product.serialized_inventory_control:
+                continue
+            while move.quantity > 1:
+                Move.copy([move], {'quantity': 1})
+                move.quantity -= 1
+            move.save()
+
+    @classmethod
+    @ModelView.button
+    def split_moves(cls, shipments):
+        "Split incoming moves with quantity greater than 1"
+        for shipment in shipments:
+            shipment._split_moves()
+
+
+class Move:
+    "Move"
+    __name__ = "stock.move"
+
+    @classmethod
+    def __setup__(cls):
+        super(Move, cls).__setup__()
+        cls._error_messages.update({
+            'quantity_one': "Quantity for moves with products having serialized"
+                            " inventory control cannot be greater than 1."
+        })
+
+    def check_product_serial(self):
+        """
+        Ensure that products with serialized inventory control have only 1 as
+        quantity for stock moves.
+        """
+        if self.state == 'done' and \
+            self.product.template.serialized_inventory_control and \
+                self.quantity != 1.0:
+            self.raise_user_error('quantity_one')
+
+    @classmethod
+    def validate(cls, moves):
+        """
+        Check if quantity is one when serialized inventory control is true for
+        each incoming move
+        """
+        super(Move, cls).validate(moves)
+        for move in moves:
+            move.check_product_serial()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+    __init__
+
+    Test Suite
+
+    :copyright: (c) 2013-2014 by Openlabs Technologies & Consulting (P) Limited
+    :license: 3-clause BSD, see LICENSE for more details.
+"""
+import unittest
+import trytond.tests.test_tryton
+from test_shipment import TestShipmentIn
+from test_views_depends import TestViewsDepends
+
+
+def suite():
+    """
+    Define suite
+    """
+    test_suite = trytond.tests.test_tryton.suite()
+    test_suite.addTests([
+        unittest.TestLoader().loadTestsFromTestCase(TestShipmentIn),
+        unittest.TestLoader().loadTestsFromTestCase(TestViewsDepends),
+    ])
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -1,0 +1,347 @@
+# -*- coding: utf-8 -*-
+"""
+    stock_lot_serial.tests.test_shipment
+
+    Test Shipment
+
+    :copyright: (c) 2013-2014 by Openlabs Technologies & Consulting (P) Limited
+    :license: 3-clause BSD, see LICENSE for more details.
+"""
+import unittest
+from decimal import Decimal
+
+import trytond.tests.test_tryton
+from trytond.tests.test_tryton import POOL, DB_NAME, USER, CONTEXT
+from trytond.transaction import Transaction
+from trytond.exceptions import UserError
+
+
+class TestShipmentIn(unittest.TestCase):
+    '''
+    Test shipment
+    '''
+
+    def setUp(self):
+        """
+        Set up data used in the tests.
+        this method is called before each test function execution.
+        """
+        trytond.tests.test_tryton.install_module('stock_lot_serial')
+
+    def create_defaults(self):
+        "Create defaults"
+        Template = POOL.get('product.template')
+        Product = POOL.get('product.product')
+        Uom = POOL.get('product.uom')
+        Party = POOL.get('party.party')
+        User = POOL.get('res.user')
+        Company = POOL.get('company.company')
+        Lot = POOL.get('stock.lot')
+        LotType = POOL.get('stock.lot.type')
+
+        party, = Party.create([{'name': 'testuser'}])
+        self.assert_(party.id)
+
+        Currency = POOL.get('currency.currency')
+        currency = Currency(
+            name='Euro', symbol=u'€', code='EUR',
+            rounding=Decimal('0.01'), mon_grouping='[3, 3, 0]',
+            mon_decimal_point=','
+        )
+        currency.save()
+        company, = Company.create([{
+            'party': party.id,
+            'currency': currency
+        }])
+        company2, = Company.create([{
+            'party': party.id,
+            'currency': currency
+        }])
+
+        User.write(
+            [User(USER)], {
+                'main_company': company.id,
+                'company': company.id,
+            }
+        )
+
+        lot_type, = LotType.search([('name', '=', 'Supplier')])
+        uom, = Uom.search([('name', '=', 'Unit')])
+        template1, = Template.create([{
+            'name': 'product',
+            'type': 'goods',
+            'list_price': Decimal('20'),
+            'cost_price': Decimal('5'),
+            'default_uom': uom,
+            'serialized_inventory_control': False,
+            'lot_required': [('set', [lot_type.id])]
+        }])
+
+        template2, = Template.create([{
+            'name': 'product',
+            'type': 'goods',
+            'list_price': Decimal('20'),
+            'cost_price': Decimal('5'),
+            'default_uom': uom,
+            'serialized_inventory_control': True,
+            'lot_required': [('set', [lot_type.id])]
+        }])
+
+        product1, = Product.create([{
+            'template': template1.id,
+        }])
+        lot1, = Lot.create([{
+            'number': 'LN01',
+            'product': product1.id,
+        }])
+
+        product2, = Product.create([{
+            'template': template2.id,
+        }])
+        lot2, = Lot.create([{
+            'number': 'LN02',
+            'product': product2.id,
+        }])
+
+        return {
+            'party': party,
+            'company': company,
+            'currency': currency,
+            'uom': uom,
+            'product1': product1,
+            'template1': template1,
+            'lot1': lot1,
+            'product2': product2,
+            'template2': template2,
+            'lot2': lot2,
+        }
+
+    def _create_non_serialized_product_shipment(self, defaults):
+        "Create a shipment with product that has inventory control set to false"
+        ShipmentIn = POOL.get('stock.shipment.in')
+        Location = POOL.get('stock.location')
+
+        supplier, = Location.search([('code', '=', 'SUP')])
+        warehouse, = Location.search([('code', '=', 'WH')])
+        inputzone, = Location.search([('code', '=', 'IN')])
+        shipment, = ShipmentIn.create([{
+            'company': defaults['company'],
+            'supplier': defaults['party'],
+            'warehouse': warehouse.id,
+            'moves': [('create', [{
+                'product': defaults['product1'],
+                'uom': defaults['uom'],
+                'from_location': supplier,
+                'to_location': inputzone,
+                'company': defaults['company'],
+                'quantity': 3.0,
+                'currency': defaults['currency'],
+                'unit_price': Decimal(2.0),
+                'lot': defaults['lot1'].id,
+            }])],
+        }])
+        return shipment
+
+    def _create_serialized_move_shipment(self, defaults):
+        """
+        Create a shipment with product that has inventory control set to true
+        and move with quantity greater than 1
+        """
+        ShipmentIn = POOL.get('stock.shipment.in')
+        Location = POOL.get('stock.location')
+
+        supplier, = Location.search([('code', '=', 'SUP')])
+        warehouse, = Location.search([('code', '=', 'WH')])
+        inputzone, = Location.search([('code', '=', 'IN')])
+        shipment, = ShipmentIn.create([{
+            'company': defaults['company'],
+            'supplier': defaults['party'],
+            'warehouse': warehouse.id,
+            'moves': [('create', [{
+                'product': defaults['product2'],
+                'uom': defaults['uom'],
+                'from_location': supplier,
+                'to_location': inputzone,
+                'company': defaults['company'],
+                'quantity': 3.0,
+                'currency': defaults['currency'],
+                'unit_price': Decimal(2.0),
+                'lot': defaults['lot2'].id,
+            }])]
+        }])
+        return shipment
+
+    def _create_mixed_serialized_shipment(self, defaults):
+        '''
+        Create a shipment with both serialized and non-serialized inventory
+        controlled products
+        '''
+        ShipmentIn = POOL.get('stock.shipment.in')
+        Location = POOL.get('stock.location')
+
+        supplier, = Location.search([('code', '=', 'SUP')])
+        warehouse, = Location.search([('code', '=', 'WH')])
+        inputzone, = Location.search([('code', '=', 'IN')])
+        shipment, = ShipmentIn.create([{
+            'company': defaults['company'],
+            'supplier': defaults['party'],
+            'warehouse': warehouse.id,
+            'moves': [('create', [
+                {
+                    'product': defaults['product1'],
+                    'uom': defaults['uom'],
+                    'from_location': supplier,
+                    'to_location': inputzone,
+                    'company': defaults['company'],
+                    'quantity': 3.0,
+                    'currency': defaults['currency'],
+                    'unit_price': Decimal(2.0),
+                    'lot': defaults['lot1'].id,
+                },
+                {
+                    'product': defaults['product2'],
+                    'uom': defaults['uom'],
+                    'from_location': supplier,
+                    'to_location': inputzone,
+                    'company': defaults['company'],
+                    'quantity': 3.0,
+                    'currency': defaults['currency'],
+                    'unit_price': Decimal(2.0),
+                    'lot': defaults['lot2'].id,
+                },
+            ])]
+        }])
+        return shipment
+
+    def test0010incoming_move_serialized(self):
+        '''
+        Tests receiving of shipment having product with serialized inventory
+        control
+        '''
+        Location = POOL.get('stock.location')
+        ShipmentIn = POOL.get('stock.shipment.in')
+
+        with Transaction().start(DB_NAME, USER, context=CONTEXT):
+            defaults = self.create_defaults()
+            supplier, = Location.search([('code', '=', 'SUP')])
+            warehouse, = Location.search([('code', '=', 'WH')])
+            inputzone, = Location.search([('code', '=', 'IN')])
+
+            # Shipment with product serialized inventory control = true
+            shipment1 = self._create_non_serialized_product_shipment(defaults)
+            self.assertTrue(shipment1.id)
+
+            # should not throw exception as serialized_inventory_control is
+            # set to false in product
+            ShipmentIn.receive([shipment1])
+
+    def test0020incoming_move_non_serialized_no_split(self):
+        '''
+        Tests receiving of shipment having product with non-serialized inventory
+        control
+        '''
+        Location = POOL.get('stock.location')
+        ShipmentIn = POOL.get('stock.shipment.in')
+
+        with Transaction().start(DB_NAME, USER, context=CONTEXT):
+            defaults = self.create_defaults()
+            supplier, = Location.search([('code', '=', 'SUP')])
+            warehouse, = Location.search([('code', '=', 'WH')])
+            inputzone, = Location.search([('code', '=', 'IN')])
+
+            # Shipment with product serialized inventory control = false and
+            # quantity > 1
+            shipment2 = self._create_serialized_move_shipment(defaults)
+
+            with self.assertRaises(UserError):
+                # Try to recieve shipment2. Since, serialized_inventory_control
+                # is set true for product and quantity is greater than 1,
+                # UserError should be raised.
+                ShipmentIn.receive([shipment2])
+
+    def test0030incoming_move_non_serialized_split(self):
+        '''
+        Test splitting of moves in shipment
+        '''
+        Location = POOL.get('stock.location')
+        ShipmentIn = POOL.get('stock.shipment.in')
+
+        with Transaction().start(DB_NAME, USER, context=CONTEXT):
+            defaults = self.create_defaults()
+            supplier, = Location.search([('code', '=', 'SUP')])
+            warehouse, = Location.search([('code', '=', 'WH')])
+            inputzone, = Location.search([('code', '=', 'IN')])
+
+            # Shipment with product serialized inventory control = false and
+            # quantity > 1
+            shipment3 = self._create_serialized_move_shipment(defaults)
+            # first check if every move has expected value
+            self.assertEqual(len(shipment3.incoming_moves), 1)
+
+            for move in shipment3.incoming_moves:
+                self.assertEqual(move.quantity, 3.0)
+
+            ShipmentIn.split_moves([shipment3])
+            shipment3 = ShipmentIn(shipment3.id)
+            self.assertEqual(len(shipment3.incoming_moves), 3)
+
+            for move in shipment3.incoming_moves:
+                self.assertEqual(move.quantity, 1.0)
+
+    def test0040incoming_move_mixed_receive(self):
+        '''
+        Test shipment with both serialized and non-serialized shipments
+        '''
+        Location = POOL.get('stock.location')
+        ShipmentIn = POOL.get('stock.shipment.in')
+
+        with Transaction().start(DB_NAME, USER, context=CONTEXT):
+            defaults = self.create_defaults()
+            supplier, = Location.search([('code', '=', 'SUP')])
+            warehouse, = Location.search([('code', '=', 'WH')])
+            inputzone, = Location.search([('code', '=', 'IN')])
+
+            shipment = self._create_mixed_serialized_shipment(defaults)
+            # first check if every move has expected value
+            self.assertEqual(len(shipment.incoming_moves), 2)
+
+            with self.assertRaises(UserError):
+                ShipmentIn.receive([shipment])
+
+    def test0040incoming_move_mixed_split(self):
+        '''
+        Test shipment with both serialized and non-serialized shipments
+        '''
+        Location = POOL.get('stock.location')
+        ShipmentIn = POOL.get('stock.shipment.in')
+
+        with Transaction().start(DB_NAME, USER, context=CONTEXT):
+            defaults = self.create_defaults()
+            supplier, = Location.search([('code', '=', 'SUP')])
+            warehouse, = Location.search([('code', '=', 'WH')])
+            inputzone, = Location.search([('code', '=', 'IN')])
+
+            shipment = self._create_mixed_serialized_shipment(defaults)
+            # first check if every move has expected value
+            self.assertEqual(len(shipment.incoming_moves), 2)
+
+            ShipmentIn.split_moves([shipment])
+            self.assertEqual(len(shipment.incoming_moves), 4)
+
+            for move in shipment.incoming_moves:
+                if move.product.serialized_inventory_control:
+                    self.assertEqual(move.quantity, 1.0)
+
+
+def suite():
+    """
+    Define suite
+    """
+    test_suite = trytond.tests.test_tryton.suite()
+    test_suite.addTests(
+        unittest.TestLoader().loadTestsFromTestCase(TestShipmentIn)
+    )
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/test_views_depends.py
+++ b/tests/test_views_depends.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+    stock_lot_serial.tests.test_views_depends
+
+    Test tryton views and fields dependency.
+
+    :copyright: (C) 2013-2014 by Openlabs Technologies & Consulting (P) Limited
+    :license: 3-clause BSD, see LICENSE for more details.
+"""
+import sys
+import os
+DIR = os.path.abspath(os.path.normpath(os.path.join(
+    __file__, '..', '..', '..', '..', '..', 'trytond'
+)))
+if os.path.isdir(DIR):
+    sys.path.insert(0, os.path.dirname(DIR))
+import unittest
+
+import trytond.tests.test_tryton
+from trytond.tests.test_tryton import test_view, test_depends
+
+
+class TestViewsDepends(unittest.TestCase):
+    '''
+    Test views and depends
+    '''
+
+    def setUp(self):
+        """
+        Set up data used in the tests.
+        this method is called before each test function execution.
+        """
+        trytond.tests.test_tryton.install_module('stock_lot_serial')
+
+    def test0005views(self):
+        '''
+        Test views.
+        '''
+        test_view('stock_lot_serial')
+
+    def test0006depends(self):
+        '''
+        Test depends.
+        '''
+        test_depends()
+
+
+def suite():
+    """
+    Define suite
+    """
+    test_suite = trytond.tests.test_tryton.suite()
+    test_suite.addTests(
+        unittest.TestLoader().loadTestsFromTestCase(TestViewsDepends)
+    )
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tryton.cfg
+++ b/tryton.cfg
@@ -1,0 +1,7 @@
+[tryton]
+version=3.0.1.0dev1
+depends:
+    stock_lot
+xml:
+    product.xml
+    shipment.xml

--- a/view/shipment_in_form.xml
+++ b/view/shipment_in_form.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<data>
+    <xpath expr="//button[@name='cancel']" position="after">
+        <button name="split_moves" string="Split Moves" />
+    </xpath>
+</data>

--- a/view/template_form.xml
+++ b/view/template_form.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<data>
+    <xpath expr="/form/notebook/page[@id='lots']/field[@name='lot_required']"
+        position="before">
+        <label name="serialized_inventory_control" />
+        <field name="serialized_inventory_control" />
+    </xpath>
+</data>


### PR DESCRIPTION
- Added a boolean field to product to enable serialized inventory
  control.
- While receiving shipments moves can't have quantity greater than one
  for serialized inventory controlled products.
- A split button is proved to split moved with serialized inventory controlled
  product into moves with quantity 1.
